### PR TITLE
Add CepstralADM and CochleagramADM branches to ADM

### DIFF
--- a/nkululeko/feat_extract/feats_cochleagram.py
+++ b/nkululeko/feat_extract/feats_cochleagram.py
@@ -1,0 +1,288 @@
+"""Cochleagram feature extraction helpers."""
+
+import os
+from multiprocessing import Pool
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+import nkululeko.glob_conf as glob_conf
+from nkululeko.constants import SAMPLING_RATE
+from nkululeko.feat_extract.feats_audio import read_indexed_audio, series_to_float_df
+from nkululeko.feat_extract.featureset import Featureset
+
+try:
+    import pycochleagram.cochleagram as cgram
+
+    _PYCOCHLEAGRAM_AVAILABLE = True
+except (ImportError, AttributeError, OSError):
+    cgram = None
+    _PYCOCHLEAGRAM_AVAILABLE = False
+
+# Lower priority for worker processes so extraction yields CPU to other
+# users' jobs on shared machines instead of competing with them head-on.
+_WORKER_NICENESS = 10
+
+_worker_extractor = None
+
+
+def _init_cochleagram_worker(extractor_kwargs):
+    global _worker_extractor
+    try:
+        os.nice(_WORKER_NICENESS)
+    except OSError:
+        pass
+    _worker_extractor = CochleagramFeatureExtractor(**extractor_kwargs)
+
+
+def _cochleagram_worker(row_index):
+    try:
+        signal, _ = read_indexed_audio(row_index, _worker_extractor.sample_rate)
+        return row_index, _worker_extractor.extract(signal[0]), None
+    except Exception as e:
+        return row_index, None, str(e)
+
+
+N_BANDS = 40
+LOW_LIM = 50
+HI_LIM = 8000
+SAMPLE_FACTOR = 2
+NONLINEARITY = "db"
+DOWNSAMPLE = None
+FFT_MODE = "auto"
+STRICT = True
+
+
+def _optional_int(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    if text.lower() in {"", "none", "false"}:
+        return None
+    return int(text)
+
+
+def _optional_str(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    if text.lower() in {"", "none", "false"}:
+        return None
+    return text
+
+
+class CochleagramFeatureExtractor:
+    """Extract summary statistics from cochleagram envelopes."""
+
+    _warned = False
+
+    def __init__(
+        self,
+        sample_rate,
+        n_bands=N_BANDS,
+        low_lim=LOW_LIM,
+        hi_lim=HI_LIM,
+        sample_factor=SAMPLE_FACTOR,
+        downsample=DOWNSAMPLE,
+        nonlinearity=NONLINEARITY,
+        fft_mode=FFT_MODE,
+        padding_size=None,
+        strict=STRICT,
+    ):
+        self.sample_rate = sample_rate
+        self.n_bands = n_bands
+        self.low_lim = low_lim
+        self.hi_lim = hi_lim
+        self.sample_factor = sample_factor
+        self.downsample = downsample
+        self.nonlinearity = nonlinearity
+        self.fft_mode = fft_mode
+        self.padding_size = padding_size
+        self.strict = strict
+        self.available = _PYCOCHLEAGRAM_AVAILABLE
+        self.warning = (
+            "WARNING: pycochleagram not installed, skipping cochleagram features. "
+            "Install from source: git clone https://github.com/mcdermottLab/pycochleagram "
+            "&& cd pycochleagram && python setup.py install"
+        )
+
+    def warn_unavailable(self):
+        if not self._warned:
+            print(self.warning)
+            self._warned = True
+
+    def extract(self, signal_tensor):
+        """Return cochleagram mean/std features for a mono signal tensor."""
+        if not self.available:
+            self.warn_unavailable()
+            return {}
+
+        if hasattr(signal_tensor, "cpu"):
+            signal_np = signal_tensor.cpu().numpy().astype(np.float32)
+        else:
+            signal_np = np.asarray(signal_tensor, dtype=np.float32)
+        signal_np = signal_np.reshape(-1)
+
+        coch = cgram.human_cochleagram(
+            signal_np,
+            sr=self.sample_rate,
+            n=self.n_bands,
+            low_lim=self.low_lim,
+            hi_lim=self.hi_lim,
+            sample_factor=self.sample_factor,
+            padding_size=self.padding_size,
+            downsample=self.downsample,
+            nonlinearity=self.nonlinearity,
+            fft_mode=self.fft_mode,
+            ret_mode="envs",
+            strict=self.strict,
+        )
+        coch_np = np.asarray(coch, dtype=np.float32)
+        if coch_np.ndim == 1:
+            coch_np = coch_np[np.newaxis, :]
+        elif coch_np.ndim > 2:
+            coch_np = np.squeeze(coch_np)
+            if coch_np.ndim == 1:
+                coch_np = coch_np[np.newaxis, :]
+
+        emb = {}
+        for i in range(coch_np.shape[0]):
+            band = coch_np[i]
+            emb[f"cochleagram_{i}_mean"] = float(np.mean(band))
+            emb[f"cochleagram_{i}_std"] = float(np.std(band))
+        return emb
+
+
+class CochleagramSet(Featureset):
+    """Top-level feature set for `[FEATS] type = ['cochleagram']`."""
+
+    def __init__(self, name, data_df, feats_type):
+        super().__init__(name, data_df, feats_type)
+        self.sample_rate = int(
+            self.util.config_val("FEATS", "cochleagram.sample_rate", SAMPLING_RATE)
+        )
+        default_hi_lim = min(HI_LIM, max(1, self.sample_rate // 2))
+        self.n_bands = int(
+            self.util.config_val("FEATS", "cochleagram.n_bands", N_BANDS)
+        )
+        self.low_lim = int(
+            self.util.config_val("FEATS", "cochleagram.low_lim", LOW_LIM)
+        )
+        self.hi_lim = int(
+            self.util.config_val("FEATS", "cochleagram.hi_lim", default_hi_lim)
+        )
+        self.sample_factor = int(
+            self.util.config_val("FEATS", "cochleagram.sample_factor", SAMPLE_FACTOR)
+        )
+        self.downsample = _optional_str(
+            self.util.config_val("FEATS", "cochleagram.downsample", DOWNSAMPLE)
+        )
+        self.nonlinearity = _optional_str(
+            self.util.config_val("FEATS", "cochleagram.nonlinearity", NONLINEARITY)
+        )
+        self.fft_mode = _optional_str(
+            self.util.config_val("FEATS", "cochleagram.fft_mode", FFT_MODE)
+        ) or FFT_MODE
+        self.padding_size = _optional_int(
+            self.util.config_val("FEATS", "cochleagram.padding_size", None)
+        )
+        self.strict = (
+            str(self.util.config_val("FEATS", "cochleagram.strict", STRICT))
+            .strip()
+            .lower()
+            == "true"
+        )
+        self.extractor = CochleagramFeatureExtractor(
+            sample_rate=self.sample_rate,
+            n_bands=self.n_bands,
+            low_lim=self.low_lim,
+            hi_lim=self.hi_lim,
+            sample_factor=self.sample_factor,
+            downsample=self.downsample,
+            nonlinearity=self.nonlinearity,
+            fft_mode=self.fft_mode,
+            padding_size=self.padding_size,
+            strict=self.strict,
+        )
+
+    def extract(self):
+        """Extract cochleagram features or load them from disk if present."""
+        store = self.util.get_path("store")
+        store_format = self.util.config_val("FEATS", "store_format", "pkl")
+        storage = f"{store}{self.name}_v2.{store_format}"
+        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
+        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
+        if extract or no_reuse or not os.path.isfile(storage):
+            self.util.debug("extracting cochleagram, this might take a while...")
+            self.df = self._extract_index(self.data_df.index)
+            self.util.write_store(self.df, storage, store_format)
+            try:
+                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+            except KeyError:
+                pass
+        else:
+            self.util.debug("reusing extracted cochleagram values")
+            self.df = self.util.get_store(storage, store_format)
+            if self.df.isnull().values.any():
+                nanrows = self.df.columns[self.df.isna().any()].tolist()
+                print(nanrows)
+                self.util.error(
+                    f"got nan: {self.df.shape} {self.df.isnull().sum().sum()}"
+                )
+
+    def extract_sample(self, signal, sr):
+        if not self.extractor.available:
+            self.extractor.warn_unavailable()
+            return pd.DataFrame([{}]).to_numpy()
+        feats = self.extractor.extract(signal)
+        return pd.DataFrame([feats]).astype(float).to_numpy()
+
+    def _extract_index(self, file_index):
+        if not self.extractor.available:
+            self.extractor.warn_unavailable()
+            return pd.DataFrame(index=file_index)
+        emb_series = pd.Series(index=file_index, dtype=object)
+        skipped = 0
+        row_list = file_index.to_list()
+        n_jobs = max(1, min(int(getattr(self, "n_jobs", 1)), os.cpu_count() or 1))
+
+        if n_jobs > 1 and len(row_list) > 1:
+            extractor_kwargs = dict(
+                sample_rate=self.sample_rate,
+                n_bands=self.n_bands,
+                low_lim=self.low_lim,
+                hi_lim=self.hi_lim,
+                sample_factor=self.sample_factor,
+                downsample=self.downsample,
+                nonlinearity=self.nonlinearity,
+                fft_mode=self.fft_mode,
+                padding_size=self.padding_size,
+                strict=self.strict,
+            )
+            with Pool(
+                processes=n_jobs,
+                initializer=_init_cochleagram_worker,
+                initargs=(extractor_kwargs,),
+            ) as pool:
+                for row_index, emb, err in tqdm(
+                    pool.imap(_cochleagram_worker, row_list), total=len(row_list)
+                ):
+                    if err is not None:
+                        print(f"WARNING: featureset: skipping {row_index}: {err}")
+                        skipped += 1
+                    else:
+                        emb_series[row_index] = emb
+        else:
+            for row_index in row_list:
+                try:
+                    signal, _ = read_indexed_audio(row_index, self.sample_rate)
+                    emb_series[row_index] = self.extractor.extract(signal[0])
+                except Exception as e:
+                    print(f"WARNING: featureset: skipping {row_index}: {e}")
+                    skipped += 1
+        if skipped:
+            print(
+                f"WARNING: featureset: skipped {skipped} files that failed to load or extract cochleagram features"
+            )
+        return series_to_float_df(emb_series)

--- a/nkululeko/feat_extract/feats_mfcc.py
+++ b/nkululeko/feat_extract/feats_mfcc.py
@@ -1,0 +1,175 @@
+"""MFCC feature extraction helpers."""
+
+import os
+
+import numpy as np
+import pandas as pd
+
+import nkululeko.glob_conf as glob_conf
+from nkululeko.constants import SAMPLING_RATE
+from nkululeko.feat_extract.feats_audio import read_indexed_audio, series_to_float_df
+from nkululeko.feat_extract.featureset import Featureset
+
+try:
+    import torch
+    import torchaudio.transforms as T_audio
+
+    _TORCHAUDIO_MFCC = True
+except (ImportError, AttributeError, OSError):
+    _TORCHAUDIO_MFCC = False
+
+
+# All values below are overridable via the [FEATS] section of the INI file
+# (e.g. mfcc.n_mfcc, mfcc.frame_length); they only serve as defaults.
+N_MFCC = 40  # Number of MFCC coefficients.
+FRAME_LENGTH = 400  # Frame length.
+FRAME_PERIOD = 80  # Frame period.
+N_FFT = 512  # FFT length.
+N_MELS = 128  # Number of mel filterbanks (must be >= n_mfcc).
+
+
+class MfccFeatureExtractor:
+    """Extract summary statistics from mel-frequency cepstral coefficients."""
+
+    # Class-level default so the flag is readable even on instances built
+    # without __init__ (e.g. unit tests using __new__).
+    _warned = False
+
+    def __init__(
+        self,
+        sample_rate,
+        frame_length,
+        frame_period,
+        fft_length,
+        device="cpu",
+        n_mfcc=N_MFCC,
+        n_mels=N_MELS,
+    ):
+        self.available = False
+        self.warning = (
+            "WARNING: torchaudio MFCC not available (requires torchaudio>=0.11), "
+            "skipping mfcc features"
+        )
+
+        if not _TORCHAUDIO_MFCC:
+            return
+
+        try:
+            self.transform = T_audio.MFCC(
+                sample_rate=sample_rate,
+                n_mfcc=n_mfcc,
+                melkwargs={
+                    "n_fft": fft_length,
+                    "win_length": frame_length,
+                    "hop_length": frame_period,
+                    "n_mels": n_mels,
+                },
+            ).to(device)
+            self.available = True
+        except Exception:
+            self.available = False
+
+    def warn_unavailable(self):
+        """Print the dependency warning once when the extractor is unavailable."""
+        if not self._warned:
+            print(self.warning)
+            self._warned = True
+
+    def extract(self, signal_tensor):
+        """Return MFCC mean/std features for a mono signal tensor."""
+        if not self.available:
+            self.warn_unavailable()
+            return {}
+
+        # MFCC expects (channel, time); output is (channel, n_mfcc, frames).
+        mfcc_out = self.transform(signal_tensor.unsqueeze(0))
+        mfcc_np = mfcc_out.squeeze(0).cpu().numpy()
+
+        emb = {}
+        for i in range(mfcc_np.shape[0]):
+            emb[f"mfcc_{i}_mean"] = np.mean(mfcc_np[i])
+            emb[f"mfcc_{i}_std"] = np.std(mfcc_np[i])
+        return emb
+
+
+class MfccSet(Featureset):
+    """Top-level feature set for `[FEATS] type = ['mfcc']`."""
+
+    def __init__(self, name, data_df, feats_type):
+        super().__init__(name, data_df, feats_type)
+        cuda = "cuda" if _TORCHAUDIO_MFCC and torch.cuda.is_available() else "cpu"
+        self.device = self.util.config_val("MODEL", "device", cuda)
+        self.frame_length = int(
+            self.util.config_val("FEATS", "mfcc.frame_length", FRAME_LENGTH)
+        )
+        self.frame_period = int(
+            self.util.config_val("FEATS", "mfcc.frame_period", FRAME_PERIOD)
+        )
+        self.fft_length = int(self.util.config_val("FEATS", "mfcc.fft_length", N_FFT))
+        self.sample_rate = int(
+            self.util.config_val("FEATS", "mfcc.sample_rate", SAMPLING_RATE)
+        )
+        self.n_mfcc = int(self.util.config_val("FEATS", "mfcc.n_mfcc", N_MFCC))
+        self.n_mels = int(self.util.config_val("FEATS", "mfcc.n_mels", N_MELS))
+        self.extractor = MfccFeatureExtractor(
+            sample_rate=self.sample_rate,
+            frame_length=self.frame_length,
+            frame_period=self.frame_period,
+            fft_length=self.fft_length,
+            device=self.device,
+            n_mfcc=self.n_mfcc,
+            n_mels=self.n_mels,
+        )
+
+    def extract(self):
+        """Extract MFCC features or load them from disk if present."""
+        store = self.util.get_path("store")
+        store_format = self.util.config_val("FEATS", "store_format", "pkl")
+        storage = f"{store}{self.name}.{store_format}"
+        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
+        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
+        if extract or no_reuse or not os.path.isfile(storage):
+            self.util.debug("extracting MFCC, this might take a while...")
+            self.df = self._extract_index(self.data_df.index)
+            self.util.write_store(self.df, storage, store_format)
+            try:
+                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+            except KeyError:
+                pass
+        else:
+            self.util.debug("reusing extracted MFCC values")
+            self.df = self.util.get_store(storage, store_format)
+            if self.df.isnull().values.any():
+                nanrows = self.df.columns[self.df.isna().any()].tolist()
+                print(nanrows)
+                self.util.error(
+                    f"got nan: {self.df.shape} {self.df.isnull().sum().sum()}"
+                )
+
+    def extract_sample(self, signal, _sr):
+        if not self.extractor.available:
+            self.extractor.warn_unavailable()
+            return pd.DataFrame([{}]).to_numpy()
+        signal_tensor = torch.tensor(signal, device=self.device).float()
+        feats = self.extractor.extract(signal_tensor)
+        return pd.DataFrame([feats]).astype(float).to_numpy()
+
+    def _extract_index(self, file_index):
+        if not self.extractor.available:
+            self.extractor.warn_unavailable()
+            return pd.DataFrame(index=file_index)
+        emb_series = pd.Series(index=file_index, dtype=object)
+        skipped = 0
+        for row_index in file_index.to_list():
+            try:
+                signal, _ = read_indexed_audio(row_index, self.sample_rate)
+                signal_tensor = torch.tensor(signal[0], device=self.device).float()
+                emb_series[row_index] = self.extractor.extract(signal_tensor)
+            except Exception as e:
+                print(f"WARNING: featureset: skipping {row_index}: {e}")
+                skipped += 1
+        if skipped:
+            print(
+                f"WARNING: featureset: skipped {skipped} files that failed to load or extract MFCC features"
+            )
+        return series_to_float_df(emb_series)

--- a/nkululeko/feature_extractor.py
+++ b/nkululeko/feature_extractor.py
@@ -114,6 +114,8 @@ class FeatureExtractor:
             "sptk",
             "lfcc",
             "cqcc",
+            "mfcc",
+            "cochleagram",
         ):
             return self._get_feat_extractor_by_name(feats_type)
         else:

--- a/nkululeko/models/model_adm.py
+++ b/nkululeko/models/model_adm.py
@@ -6,6 +6,8 @@ Multi-stream neural model that detects synthesis artifacts using:
 - TimeADM: temporal/micro-prosodic artifacts from SSL features
 - SpectralADM: spectral/vocoder artifacts from mel-filterbank features
 - PhaseADM: phase-dynamics artifacts from STFT features
+- CepstralADM: cepstral-domain artifacts from concatenated MFCC/LFCC/CQCC features
+- CochleagramADM: auditory-model artifacts from cochleagram envelope features
 """
 
 import json
@@ -137,12 +139,22 @@ class ADMModel(Model):
         hidden_dim = int(self.util.config_val("MODEL", "adm.hidden_dim", "256"))
 
         # Branch selection: time (SSL), spectral (fbank/melspec), phase (STFT),
-        # plus optional cepstral streams such as lfcc/cqcc.
+        # plus optional cepstral streams: lfcc/cqcc individually, or the
+        # combined cepstral branch (MFCC+LFCC+CQCC), plus an optional
+        # cochleagram branch (auditory-model ERB filterbank envelopes).
         branches_str = self.util.config_val(
             "MODEL", "adm.branches", "time,spectral,phase,lfcc,cqcc"
         )
         raw_branches = [b.strip() for b in branches_str.split(",") if b.strip()]
-        supported_branches = {"time", "spectral", "phase", "lfcc", "cqcc"}
+        supported_branches = {
+            "time",
+            "spectral",
+            "phase",
+            "lfcc",
+            "cqcc",
+            "cepstral",
+            "cochleagram",
+        }
         unknown_branches = [b for b in raw_branches if b not in supported_branches]
         if unknown_branches:
             raise ValueError(
@@ -155,7 +167,7 @@ class ADMModel(Model):
             raise ValueError(
                 "No valid ADM branches configured. "
                 "Please set [MODEL] adm.branches to a non-empty subset of "
-                "{'time','spectral','phase','lfcc','cqcc'}."
+                "{'time','spectral','phase','lfcc','cqcc','cepstral','cochleagram'}."
             )
         self.branches = branches
         self.util.debug(f"ADM active branches: {branches}")
@@ -295,18 +307,36 @@ class ADMModel(Model):
 
     @staticmethod
     def _get_adm_stream_indices(columns, ssl_feat_dim):
-        """Return acoustic feature column indices for ADM streams."""
+        """Return acoustic feature column indices for ADM streams.
+
+        The "cepstral" extra stream concatenates MFCC, LFCC, and CQCC
+        columns (in that order) so the CepstralADM branch can jointly
+        consume all three classical cepstral feature families. The
+        "cochleagram" extra stream carries auditory-model (ERB
+        filterbank) envelope features for the CochleagramADM branch.
+        """
         acoustic_cols = [c for c in columns if isinstance(c, str)]
         spectral_indices = []
         phase_indices = []
-        extra_indices = {"lfcc": [], "cqcc": []}
+        extra_indices = {
+            "lfcc": [],
+            "cqcc": [],
+            "cepstral": [],
+            "cochleagram": [],
+        }
         for i, col in enumerate(acoustic_cols):
             col_idx = ssl_feat_dim + i
             col_name = str(col).lower()
-            if col_name.startswith("lfcc"):
+            if col_name.startswith("mfcc"):
+                extra_indices["cepstral"].append(col_idx)
+            elif col_name.startswith("lfcc"):
                 extra_indices["lfcc"].append(col_idx)
+                extra_indices["cepstral"].append(col_idx)
             elif col_name.startswith("cqcc"):
                 extra_indices["cqcc"].append(col_idx)
+                extra_indices["cepstral"].append(col_idx)
+            elif col_name.startswith("cochleagram"):
+                extra_indices["cochleagram"].append(col_idx)
             elif col_name.startswith("stft"):
                 phase_indices.append(col_idx)
             else:
@@ -316,11 +346,12 @@ class ADMModel(Model):
     def _active_branches(self, branches):
         """Drop optional extra branches that have no corresponding features."""
         active = []
+        extra_branch_names = ("lfcc", "cqcc", "cepstral", "cochleagram")
         has_extra_streams = any(
-            self.extra_stream_indices.get(name) for name in ("lfcc", "cqcc")
+            self.extra_stream_indices.get(name) for name in extra_branch_names
         )
         for branch in branches:
-            if branch in {"lfcc", "cqcc"}:
+            if branch in extra_branch_names:
                 if self.extra_stream_indices.get(branch):
                     active.append(branch)
             elif branch == "spectral":

--- a/nkululeko/models/model_adm_core.py
+++ b/nkululeko/models/model_adm_core.py
@@ -5,9 +5,11 @@ Artifact Detection Modules (ADMs) for deepfake detection.
 Adapted for nkululeko's aggregated features (mean-pooled, not time-series).
 
 Modules:
-- TimeADM    : Residual MLP for SSL aggregated features
-- SpectralADM: Residual MLP for spectral aggregated features
-- PhaseADM   : MLP for phase aggregated features
+- TimeADM        : Residual MLP for SSL aggregated features
+- SpectralADM    : Residual MLP for spectral aggregated features
+- PhaseADM       : MLP for phase aggregated features
+- CepstralADM    : MLP for concatenated MFCC/LFCC/CQCC cepstral features
+- CochleagramADM : MLP for cochleagram (auditory model) envelope features
 """
 
 import torch
@@ -179,6 +181,122 @@ class PhaseADM(nn.Module):
 
 
 # --------------------------------------------------
+# Cepstral Artifact Detector (Residual MLP)
+# --------------------------------------------------
+class CepstralADM(nn.Module):
+    """
+    Detects cepstral-domain artifacts using concatenated MFCC, LFCC,
+    and CQCC aggregated features.
+
+    Uses LazyLinear for the first layer since the concatenated width
+    depends on which of the three cepstral feature sets are enabled
+    and their configured coefficient counts.
+
+    Input:
+        x : (B, C) - concatenated MFCC + LFCC + CQCC aggregated features
+    Output:
+        artifact score : (B, 1)
+    """
+
+    def __init__(self, feat_dim=None, hidden_dim=128):
+        super().__init__()
+        self.feat_dim = feat_dim
+        self.hidden_dim = hidden_dim
+
+        self.fc1 = nn.LazyLinear(hidden_dim)
+        self.ln1 = nn.LayerNorm(hidden_dim)
+        self.dropout1 = nn.Dropout(0.2)
+
+        self.fc2 = nn.Linear(hidden_dim, hidden_dim)
+        self.ln2 = nn.LayerNorm(hidden_dim)
+        self.dropout2 = nn.Dropout(0.2)
+
+        self.fc3 = nn.Linear(hidden_dim, hidden_dim // 2)
+        self.ln3 = nn.LayerNorm(hidden_dim // 2)
+        self.dropout3 = nn.Dropout(0.2)
+
+        self.fc_out = nn.Linear(hidden_dim // 2, 1)
+
+    def forward(self, x):
+        # x: (B, C) or (B, C, T) - handle both cases
+        if x.dim() == 3:
+            x = x.squeeze(-1)
+
+        x = F.gelu(self.ln1(self.fc1(x)))
+        x = self.dropout1(x)
+
+        # Residual connection (fc2 preserves hidden_dim)
+        residual = x
+        x = F.gelu(self.ln2(self.fc2(x)))
+        x = self.dropout2(x)
+        x = x + residual
+
+        x = F.gelu(self.ln3(self.fc3(x)))
+        x = self.dropout3(x)
+
+        x = self.fc_out(x)
+        return x
+
+
+# --------------------------------------------------
+# Cochleagram Artifact Detector (Residual MLP)
+# --------------------------------------------------
+class CochleagramADM(nn.Module):
+    """
+    Detects auditory-model artifacts using aggregated cochleagram
+    envelope features (biologically-inspired ERB-filterbank envelopes,
+    as opposed to the linear/mel-spectral SpectralADM stream).
+
+    Uses LazyLinear for the first layer since the aggregated width
+    depends on the configured number of cochleagram frequency bands.
+
+    Input:
+        x : (B, C) - aggregated cochleagram envelope features
+    Output:
+        artifact score : (B, 1)
+    """
+
+    def __init__(self, feat_dim=None, hidden_dim=128):
+        super().__init__()
+        self.feat_dim = feat_dim
+        self.hidden_dim = hidden_dim
+
+        self.fc1 = nn.LazyLinear(hidden_dim)
+        self.ln1 = nn.LayerNorm(hidden_dim)
+        self.dropout1 = nn.Dropout(0.2)
+
+        self.fc2 = nn.Linear(hidden_dim, hidden_dim)
+        self.ln2 = nn.LayerNorm(hidden_dim)
+        self.dropout2 = nn.Dropout(0.2)
+
+        self.fc3 = nn.Linear(hidden_dim, hidden_dim // 2)
+        self.ln3 = nn.LayerNorm(hidden_dim // 2)
+        self.dropout3 = nn.Dropout(0.2)
+
+        self.fc_out = nn.Linear(hidden_dim // 2, 1)
+
+    def forward(self, x):
+        # x: (B, C) or (B, C, T) - handle both cases
+        if x.dim() == 3:
+            x = x.squeeze(-1)
+
+        x = F.gelu(self.ln1(self.fc1(x)))
+        x = self.dropout1(x)
+
+        # Residual connection (fc2 preserves hidden_dim)
+        residual = x
+        x = F.gelu(self.ln2(self.fc2(x)))
+        x = self.dropout2(x)
+        x = x + residual
+
+        x = F.gelu(self.ln3(self.fc3(x)))
+        x = self.dropout3(x)
+
+        x = self.fc_out(x)
+        return x
+
+
+# --------------------------------------------------
 # Multi-stream Artifact Detection Model
 # --------------------------------------------------
 class DeepfakeADMModel(nn.Module):
@@ -219,9 +337,15 @@ class DeepfakeADMModel(nn.Module):
             if "phase" in branches
             else None
         )
+        _extra_adm_classes = {
+            "cepstral": CepstralADM,
+            "cochleagram": CochleagramADM,
+        }
         self.extra_adms = nn.ModuleDict(
             {
-                name: SpectralADM(feat_dim=feat_dim, hidden_dim=hidden_dim)
+                name: _extra_adm_classes.get(name, SpectralADM)(
+                    feat_dim=feat_dim, hidden_dim=hidden_dim
+                )
                 for name, feat_dim in self.extra_stream_dims.items()
                 if name in branches
             }


### PR DESCRIPTION
- feats_mfcc.py: MFCC extractor (torchaudio-based), mirroring feats_lfcc.py
- feats_cochleagram.py: cochleagram envelope extractor built on pycochleagram
- feature_extractor.py: register mfcc/cochleagram feature types
- model_adm.py: detect mfcc_*/cochleagram_* columns, combine mfcc+lfcc+cqcc into a single "cepstral" stream, add "cepstral" and "cochleagram" as opt-in adm.branches values
- model_adm_core.py: add CepstralADM and CochleagramADM branch modules, wire them into DeepfakeADMModel's extra_adms

## Summary by Sourcery

Add new ADM branches that operate on combined cepstral features and cochleagram envelope features, and wire them into branch selection and feature stream handling.

New Features:
- Introduce MFCC-based feature extraction and a corresponding MFCC feature set.
- Introduce cochleagram envelope feature extraction and a corresponding cochleagram feature set.
- Add CepstralADM and CochleagramADM branches to the multi-stream artifact detection model.
- Allow configuration of new 'cepstral' and 'cochleagram' ADM branches via adm.branches.

Enhancements:
- Extend ADM stream indexing to detect MFCC, LFCC, CQCC, and cochleagram columns and build combined cepstral and cochleagram streams.
- Generalize extra ADM branch wiring so cepstral and cochleagram streams instantiate their own ADM modules instead of always using SpectralADM.
- Update feature extractor type dispatch to recognize mfcc and cochleagram feature types.